### PR TITLE
Adjust code to work with email and Bitbucket API tokens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,31 @@
 Simple tool to list all your bitbucket workspaces and clone all repositories associated with these workspaces.
 
 ## Requirements
-1. You need to know your bitbucket username. Can be found at https://bitbucket.org/account/settings/.
-2. You need to create an app password here https://bitbucket.org/account/settings/app-passwords/ with read permissions for *account*, *workspace membership* and *repositories*.
+1. You need to know your Bitbucket account email. Can be found at https://bitbucket.org/account/settings/.
+2. You need to create an API token here https://bitbucket.org/account/settings/api-tokens/ with read permissions for *account*, *workspace membership* and *repositories*.
 3. Install bucketcloner either by cloning this repository and running `pip install .` or by installing it via `pip install bucketcloner`. Minimum required python version is 3.8.
 
 ## List all workspaces
 ```bash
-bucketcloner -u <username> -p <apppassword> workspace
+bucketcloner -e <email> -t <api_token> workspace
 ```
 This lists all workspaces, including your personal workspace, where you have access.
 
 ## Clone workspace(s)
 You can clone all repositories of all workspaces by simply calling
 ```bash
-bucketcloner -u <username> -p <password> clone
+bucketcloner -e <email> -t <api_token> clone
 ```
 This clones all repositories of all workspaces into the folders `workspace/repository` relative to the current directory.
 
 To select specific workspace(s), add the `-w` option with workspace slug names separated by commas
 ```bash
-bucketcloner -u <username> -p <password> -w workspace1,workspace2 clone
+bucketcloner -e <email> -t <api_token> -w workspace1,workspace2 clone
 ```
 
 All existing repositories in the folders will be deleted and cloned again. To just skip existing repositories, add `--skip-existing` flag.
 ```bash
-bucketcloner -u <username> -p <password> -w workspace1,workspace2 --skip-existing clone
+bucketcloner -e <email> -t <api_token> -w workspace1,workspace2 --skip-existing clone
 ```
 
 ## Python example

--- a/example.ipynb
+++ b/example.ipynb
@@ -4,23 +4,14 @@
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Example for using bucketcloner\n",
-    "_Author: Philipp Lies_\n",
-    "\n",
-    "Fill in the username and app password with sufficient permissions (at least reading account, workspaces, and repository)."
-   ]
+   "source": "# Example for using bucketcloner\n_Author: Philipp Lies_\n\nFill in the email and API token with sufficient permissions (at least reading account, workspaces, and repository)."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# TODO: Provide your information here\n",
-    "user = ''\n",
-    "password = '' "
-   ]
+   "source": "# TODO: Provide your information here\nemail = ''\ntoken = ''"
   },
   {
    "attachments": {},
@@ -37,13 +28,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import src.bucketcloner as bucketcloner\n",
-    "\n",
-    "workspaces = bucketcloner.list_bitbucket_workspaces(user, password)\n",
-    "for w in workspaces:\n",
-    "    print(f'{w[\"name\"]} ({w[\"slug\"]}) - {w[\"url\"]}')"
-   ]
+   "source": "import src.bucketcloner as bucketcloner\n\nworkspaces = bucketcloner.list_bitbucket_workspaces(email, token)\nfor w in workspaces:\n    print(f'{w[\"name\"]} ({w[\"slug\"]}) - {w[\"url\"]}')"
   },
   {
    "attachments": {},
@@ -58,10 +43,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "workspace = workspaces[-1]\n",
-    "bucketcloner.clone_bitbucket(user, password, workspace['slug'])"
-   ]
+   "source": "workspace = workspaces[-1]\nbucketcloner.clone_bitbucket(email, token, workspace['slug'])"
   },
   {
    "attachments": {},


### PR DESCRIPTION
Thank you @phillies for providing this useful package, it really saved the day for me, so I thought of contributing back what I can!

Since [Bitbucket announced that it won't allow the creation of new app passwords on 09/09/2025](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-enters-phase-2-of-app-password-deprecation), the code required some modifications in order to work with email and API tokens.

I have successfully used the following commands:

```bash
bucketcloner -e <email> -t <api_token> workspace
```

```bash
bucketcloner -e <email> -t <api_token> -w workspace1,workspace2 clone
```

It may require some more testing and checks, but the main functionality is there.